### PR TITLE
Custom exception when creds aren't found

### DIFF
--- a/src/DockerCredsProvider.Test/CredsProviderTests.cs
+++ b/src/DockerCredsProvider.Test/CredsProviderTests.cs
@@ -87,7 +87,7 @@ namespace DockerCredsProvider.Test
                     It.IsAny<Action<string?>>()))
                 .Throws(new Win32Exception(2));
 
-            await Assert.ThrowsAsync<InvalidOperationException>(() => CredsProvider.GetCredentialsAsync("test"));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => CredsProvider.GetCredentialsAsync("test", fileSystemMock.Object, processServiceMock.Object));
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace DockerCredsProvider.Test
                 })
                 .Returns(1);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
+            await Assert.ThrowsAsync<CredsNotFoundException>(
                 () => CredsProvider.GetCredentialsAsync("test", fileSystemMock.Object, processServiceMock.Object));
         }
 
@@ -199,7 +199,7 @@ namespace DockerCredsProvider.Test
                 .Setup(o => o.FileOpenRead(dockerConfigPath))
                 .Returns(new MemoryStream(Encoding.UTF8.GetBytes(dockerConfigContent)));
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
+            await Assert.ThrowsAsync<CredsNotFoundException>(
                 () => CredsProvider.GetCredentialsAsync("testregistry2", fileSystemMock.Object, Mock.Of<IProcessService>()));
         }
 

--- a/src/DockerCredsProvider/CredsNotFoundException.cs
+++ b/src/DockerCredsProvider/CredsNotFoundException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace DockerCredsProvider
+{
+    public class CredsNotFoundException : Exception
+    {
+        public CredsNotFoundException()
+        {
+        }
+
+        public CredsNotFoundException(string message)
+            : base(message)
+        {
+        }
+
+        public CredsNotFoundException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/DockerCredsProvider/CredsProvider.cs
+++ b/src/DockerCredsProvider/CredsProvider.cs
@@ -66,7 +66,7 @@ namespace DockerCredsProvider
 
                 if (property.Equals(default(JsonProperty)))
                 {
-                    throw new InvalidOperationException($"No matching auth specified for registry '{registry}' in Docker config '{dockerConfigPath}'.");
+                    throw new CredsNotFoundException($"No matching auth specified for registry '{registry}' in Docker config '{dockerConfigPath}'.");
                 }
 
                 if (property.Value.TryGetProperty("auth", out JsonElement authElement))

--- a/src/DockerCredsProvider/NativeStore.cs
+++ b/src/DockerCredsProvider/NativeStore.cs
@@ -81,9 +81,9 @@ namespace DockerCredsProvider
             {
                 string err = stdError.Length > 0 ? stdError.ToString() : stdOutput.ToString();
 
-                throw new InvalidOperationException(
-                    $"Failed to execute '{startInfo.FileName} {startInfo.Arguments}'" +
-                    Environment.NewLine + Environment.NewLine + err);
+                throw new CredsNotFoundException(
+                    $"Failed to execute '{startInfo.FileName} {startInfo.Arguments}':" +
+                    Environment.NewLine + err);
             }
 
             return stdOutput.ToString();


### PR DESCRIPTION
Throws a new custom exception, `CredsNotFoundException`, if the creds aren't able to be found from the store.  This allows callers to distinguish this particular scenario.