### PR TITLE
Support identity tokens

### DIFF
--- a/src/Valleysoft.DockerCredsProvider.Test/CredsProviderTests.cs
+++ b/src/Valleysoft.DockerCredsProvider.Test/CredsProviderTests.cs
@@ -2,6 +2,7 @@ using Moq;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using Xunit;
 
 namespace Valleysoft.DockerCredsProvider.Test;
@@ -49,6 +50,51 @@ public class CredsProviderTests
 
         Assert.Equal("testuser", creds.Username);
         Assert.Equal("password", creds.Password);
+        Assert.Null(creds.IdentityToken);
+    }
+
+    [Fact]
+    public async Task NativeStore_Token()
+    {
+        string dockerConfigPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".docker",
+            "config.json");
+
+        string credsStore = "desktop";
+
+        string dockerConfigContent =
+            "{" +
+            $"\"credsStore\": \"{credsStore}\"" +
+            "}";
+
+        Mock<IFileSystem> fileSystemMock = new();
+        fileSystemMock
+            .Setup(o => o.FileExists(dockerConfigPath))
+            .Returns(true);
+
+        fileSystemMock
+            .Setup(o => o.FileOpenRead(dockerConfigPath))
+            .Returns(new MemoryStream(Encoding.UTF8.GetBytes(dockerConfigContent)));
+
+        Mock<IProcessService> processServiceMock = new();
+        processServiceMock
+            .Setup(o => o.Run(
+                It.Is<ProcessStartInfo>(startInfo => startInfo.FileName == $"docker-credential-{credsStore}"),
+                "test",
+                It.IsAny<Action<string?>>(),
+                It.IsAny<Action<string?>>()))
+            .Callback((ProcessStartInfo startInfo, string? input, Action<string?> outputDataReceived, Action<string?> errorDataReceived) =>
+            {
+                outputDataReceived("{ \"Username\": \"<token>\", \"Secret\": \"identitytoken\" }");
+            })
+            .Returns(0);
+
+        DockerCredentials creds = await CredsProvider.GetCredentialsAsync("test", fileSystemMock.Object, processServiceMock.Object);
+
+        Assert.Equal("<token>", creds.Username);
+        Assert.Null(creds.Password);
+        Assert.Equal("identitytoken", creds.IdentityToken);
     }
 
     [Fact]
@@ -163,6 +209,7 @@ public class CredsProviderTests
 
         Assert.Equal(username, creds.Username);
         Assert.Equal(password, creds.Password);
+        Assert.Null(creds.IdentityToken);
     }
 
     [Fact]
@@ -198,6 +245,191 @@ public class CredsProviderTests
 
         await Assert.ThrowsAsync<CredsNotFoundException>(
             () => CredsProvider.GetCredentialsAsync("testregistry2", fileSystemMock.Object, Mock.Of<IProcessService>()));
+    }
+
+    [Fact]
+    public async Task EncodedStore_NoUsername()
+    {
+        string dockerConfigPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".docker",
+            "config.json");
+
+        string username = String.Empty;
+        string password = "testpass";
+
+        string encodedCreds = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+
+        string dockerConfigContent =
+            "{" +
+                "\"auths\": {" +
+                    "\"testregistry\": {" +
+                        $"\"auth\": \"{encodedCreds}\"" +
+                    "}" +
+                "}" +
+            "}";
+
+        Mock<IFileSystem> fileSystemMock = new();
+        fileSystemMock
+            .Setup(o => o.FileExists(dockerConfigPath))
+            .Returns(true);
+
+        fileSystemMock
+            .Setup(o => o.FileOpenRead(dockerConfigPath))
+            .Returns(new MemoryStream(Encoding.UTF8.GetBytes(dockerConfigContent)));
+
+        await Assert.ThrowsAsync<JsonException>(() =>
+            CredsProvider.GetCredentialsAsync("testregistry", fileSystemMock.Object, Mock.Of<IProcessService>())
+        );
+    }
+
+    [Fact]
+    public async Task EncodedStore_NoPassword()
+    {
+        string dockerConfigPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".docker",
+            "config.json");
+
+        string username = "testuser";
+        string password = "";
+
+        string encodedCreds = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+
+        string dockerConfigContent =
+            "{" +
+                "\"auths\": {" +
+                    "\"testregistry\": {" +
+                        $"\"auth\": \"{encodedCreds}\"" +
+                    "}" +
+                "}" +
+            "}";
+
+        Mock<IFileSystem> fileSystemMock = new();
+        fileSystemMock
+            .Setup(o => o.FileExists(dockerConfigPath))
+            .Returns(true);
+
+        fileSystemMock
+            .Setup(o => o.FileOpenRead(dockerConfigPath))
+            .Returns(new MemoryStream(Encoding.UTF8.GetBytes(dockerConfigContent)));
+
+        await Assert.ThrowsAsync<JsonException>(() =>
+            CredsProvider.GetCredentialsAsync("testregistry", fileSystemMock.Object, Mock.Of<IProcessService>())
+        );
+    }
+
+    [Fact]
+    public async Task EncodedStore_NoSeparator()
+    {
+        string dockerConfigPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".docker",
+            "config.json");
+
+        string username = "testuser";
+        string password = "testpassword";
+
+        string encodedCreds = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}{password}"));
+
+        string dockerConfigContent =
+            "{" +
+                "\"auths\": {" +
+                    "\"testregistry\": {" +
+                        $"\"auth\": \"{encodedCreds}\"" +
+                    "}" +
+                "}" +
+            "}";
+
+        Mock<IFileSystem> fileSystemMock = new();
+        fileSystemMock
+            .Setup(o => o.FileExists(dockerConfigPath))
+            .Returns(true);
+
+        fileSystemMock
+            .Setup(o => o.FileOpenRead(dockerConfigPath))
+            .Returns(new MemoryStream(Encoding.UTF8.GetBytes(dockerConfigContent)));
+
+        await Assert.ThrowsAsync<JsonException>(() =>
+            CredsProvider.GetCredentialsAsync("testregistry", fileSystemMock.Object, Mock.Of<IProcessService>())
+        );
+    }
+
+    [Fact]
+    public async Task EncodedStore_IdentityTokenWithUsernamePasswordSeparator()
+    {
+        string dockerConfigPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".docker",
+            "config.json");
+
+        string username = "00000000-0000-0000-0000-000000000000";
+        string password = String.Empty;
+        string token = "tokenstring";
+
+        string encodedCreds = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+
+        string dockerConfigContent =
+            "{" +
+                "\"auths\": {" +
+                    "\"testregistry\": {" +
+                        $"\"auth\": \"{encodedCreds}\"," +
+                        $"\"identitytoken\": \"{token}\"" +
+                    "}" +
+                "}" +
+            "}";
+
+        Mock<IFileSystem> fileSystemMock = new();
+        fileSystemMock
+            .Setup(o => o.FileExists(dockerConfigPath))
+            .Returns(true);
+
+        fileSystemMock
+            .Setup(o => o.FileOpenRead(dockerConfigPath))
+            .Returns(new MemoryStream(Encoding.UTF8.GetBytes(dockerConfigContent)));
+
+        DockerCredentials creds = await CredsProvider.GetCredentialsAsync("testregistry", fileSystemMock.Object, Mock.Of<IProcessService>());
+        Assert.Equal(username, creds.Username);
+        Assert.Null(creds.Password);
+        Assert.Equal(token, creds.IdentityToken);
+    }
+
+    [Fact]
+    public async Task EncodedStore_IdentityTokenWithoutUsernamePasswordSeparator()
+    {
+        string dockerConfigPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".docker",
+            "config.json");
+
+        string username = "<token>";
+        string token = "tokenstring";
+
+        string encodedCreds = Convert.ToBase64String(Encoding.UTF8.GetBytes(username));
+
+        string dockerConfigContent =
+            "{" +
+                "\"auths\": {" +
+                    "\"testregistry\": {" +
+                        $"\"auth\": \"{encodedCreds}\"," +
+                        $"\"identitytoken\": \"{token}\"" +
+                    "}" +
+                "}" +
+            "}";
+
+        Mock<IFileSystem> fileSystemMock = new();
+        fileSystemMock
+            .Setup(o => o.FileExists(dockerConfigPath))
+            .Returns(true);
+
+        fileSystemMock
+            .Setup(o => o.FileOpenRead(dockerConfigPath))
+            .Returns(new MemoryStream(Encoding.UTF8.GetBytes(dockerConfigContent)));
+
+        DockerCredentials creds = await CredsProvider.GetCredentialsAsync("testregistry", fileSystemMock.Object, Mock.Of<IProcessService>());
+        Assert.Equal(username, creds.Username);
+        Assert.Null(creds.Password);
+        Assert.Equal(token, creds.IdentityToken);
     }
 
     [Fact]

--- a/src/Valleysoft.DockerCredsProvider/CredsProvider.cs
+++ b/src/Valleysoft.DockerCredsProvider/CredsProvider.cs
@@ -65,20 +65,7 @@ public static class CredsProvider
                 throw new CredsNotFoundException($"No matching auth specified for registry '{registry}' in Docker config '{dockerConfigPath}'.");
             }
 
-            if (property.Value.TryGetProperty("auth", out JsonElement authElement))
-            {
-                string? encodedValue = authElement.GetString();
-                if (encodedValue is null)
-                {
-                    throw new JsonException($"No auth value specified for registry '{registry}' in Docker config '{dockerConfigPath}'.");
-                }
-
-                return new EncodedStore(encodedValue);
-            }
-            else
-            {
-                throw new JsonException($"Auth property doesn't exist for registry '{registry}' in Docker config '{dockerConfigPath}'.");
-            }
+            return new EncodedStore(property, dockerConfigPath);
         }
 
         throw new JsonException($"Unable to find credential information in Docker config '{dockerConfigPath}'.");

--- a/src/Valleysoft.DockerCredsProvider/DockerCredentials.cs
+++ b/src/Valleysoft.DockerCredsProvider/DockerCredentials.cs
@@ -2,13 +2,16 @@ namespace Valleysoft.DockerCredsProvider;
 
 public class DockerCredentials
 {
-    public DockerCredentials(string username, string password)
+    public DockerCredentials(string username, string? password = null, string? identityToken = null)
     {
         Username = username;
         Password = password;
+        IdentityToken = identityToken;
     }
 
     public string Username { get; }
 
-    public string Password { get; }
+    public string? Password { get; }
+
+    public string? IdentityToken { get; }
 }

--- a/src/Valleysoft.DockerCredsProvider/EncodedStore.cs
+++ b/src/Valleysoft.DockerCredsProvider/EncodedStore.cs
@@ -1,20 +1,82 @@
 ﻿using System.Text;
+using System.Text.Json;
 
 namespace Valleysoft.DockerCredsProvider;
 
 internal class EncodedStore : ICredStore
 {
-    private readonly string credentialEncoding;
+    private readonly DockerCredentials creds;
 
-    public EncodedStore(string credentialEncoding)
+    public EncodedStore(JsonProperty registryProperty, string configPath)
     {
-        this.credentialEncoding = credentialEncoding;
-    }
+        string? identityToken = null;
+        string credentialEncoding;
 
-    public Task<DockerCredentials> GetCredentialsAsync(string registry)
-    {
+        if (registryProperty.Value.TryGetProperty("identitytoken", out JsonElement tokenElement))
+        {
+            identityToken = tokenElement.GetString();
+        }
+
+        if (registryProperty.Value.TryGetProperty("auth", out JsonElement authElement))
+        {
+            string? encodedValue = authElement.GetString();
+            if (encodedValue is null)
+            {
+                throw new JsonException(
+                    $"No auth value specified for registry '{registryProperty.Name}' in Docker config '{configPath}'.");
+            }
+
+            credentialEncoding = encodedValue;
+        }
+        else
+        {
+            throw new JsonException(
+                $"Auth property doesn't exist for registry '{registryProperty.Name}' in Docker config '{configPath}'.");
+        }
+
         string decoded = Encoding.UTF8.GetString(Convert.FromBase64String(credentialEncoding));
-        string[] parts = decoded.Split(':');
-        return Task.FromResult(new DockerCredentials(parts[0], parts[1]));
+        int separatorIndex = decoded.IndexOf(':');
+
+        string username;
+        if (separatorIndex < 0)
+        {
+            if (identityToken is null)
+            {
+                throw new JsonException(
+                $"The username/password separator character ':' is missing in the decoded string from the auth value of registry '{registryProperty.Name}' in Docker config '{configPath}'.");
+            }
+
+            username = decoded;
+        }
+        else
+        {
+            username = decoded.Substring(0, separatorIndex);
+        }
+
+        if (username.Length == 0)
+        {
+            throw new JsonException(
+                $"Encoded auth value does not contain a username for registry '{registryProperty.Name}' in Docker config '{configPath}'.");
+        }
+
+        string? password = null;
+        if (separatorIndex >= 0)
+        {
+            password = decoded.Substring(separatorIndex + 1);
+        }
+
+        if (password?.Length == 0)
+        {
+            password = null;
+            if (identityToken is null)
+            {
+                throw new JsonException(
+                    $"Configuration for registry '{registryProperty.Name}' in Docker config '{configPath}' must contain either a password in the encoded auth value or have an identity token set.");
+            }
+        }
+
+        creds = new DockerCredentials(username, password, identityToken);
     }
+
+    public Task<DockerCredentials> GetCredentialsAsync(string registry) => Task.FromResult(creds);
 }


### PR DESCRIPTION
Adds support for identity tokens instead of only username/password credentials.

This is exposed in the `DockerCredentials` class by including a nullable `IdentityToken` property. It also changes the `Password` property to be nullable. Either the `IdentityToken` property or `Password` property will be set, but not both.