### PR TITLE
Allow TFM to be provided

### DIFF
--- a/src/Valleysoft.DockerCredsProvider/Valleysoft.DockerCredsProvider.csproj
+++ b/src/Valleysoft.DockerCredsProvider/Valleysoft.DockerCredsProvider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>Valleysoft.DockerCredsProvider</RootNamespace>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Allows external build systems to set the TFM of the package by setting the `TargetFrameworks` MSBuild property.

@MichaelSimons - PTAL